### PR TITLE
fix: preserve invalid Date instead of dropping it to null

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -197,6 +197,25 @@ describe('stringify & parse', () => {
       },
     },
 
+    'works for invalid dates': {
+      input: {
+        date: new Date('invalid'),
+      },
+      output: {
+        date: '',
+      },
+      outputAnnotations: {
+        values: {
+          date: ['Date'],
+        },
+      },
+      dontExpectEquality: true,
+      customExpectations: value => {
+        expect(value.date).toBeInstanceOf(Date);
+        expect(Number.isNaN(value.date.getTime())).toBe(true);
+      },
+    },
+
     'works for Errors': {
       input: {
         e: new Error('epic fail'),

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,6 +1,5 @@
 import {
   isBigint,
-  isDate,
   isInfinite,
   isMap,
   isNaNValue,
@@ -73,9 +72,12 @@ const simpleRules = [
     }
   ),
   simpleTransformation(
-    isDate,
+    (v): v is Date => v instanceof Date,
     'Date',
-    v => v.toISOString(),
+    // An invalid Date (`new Date(NaN)`) has no ISO representation and would
+    // otherwise be dropped to `null`, losing its type. Serialize it to an
+    // empty string, which `new Date('')` revives back into an invalid Date.
+    v => (isNaN(v.valueOf()) ? '' : v.toISOString()),
     v => new Date(v)
   ),
 


### PR DESCRIPTION
### Problem

`isDate` only matches dates with a valid time (`payload instanceof Date && !isNaN(payload.valueOf())`), so an invalid Date never reaches the Date transformer. It falls through to plain JSON, where `JSON.stringify(new Date(NaN))` produces `null`. After `parse`, the value comes back as `null`, losing both the value and the `Date` type:

```ts
const d = new Date(NaN);            // also: new Date('not a date')
SuperJSON.parse(SuperJSON.stringify(d)); // => null, expected an invalid Date
```

This is a silent type change. Invalid Dates turn up in real code whenever a date is built from untrusted input, e.g. `new Date(userInput)` where the input does not parse. The caller then receives `null` where it expected a `Date`, which breaks any later `.getTime()` / `.toISOString()` call.

### Fix

Match any `Date` instance in the Date rule and move the "no ISO representation" concern into the serializer: an invalid Date is serialized to an empty string, and `new Date('')` revives it back into an invalid Date. This is the same approach `devalue` uses (it stores an invalid Date as `[["Date",""]]` and reconstructs it with `new Date('')`).

`isDate` is left strict, so its existing meaning ("a valid Date") and its test stay untouched. Valid dates serialize exactly as before.

### Verification

Checked both ways, with the existing suite plus a new case:

- invalid Date serializes to `{ json: "", meta: { values: ["Date"] } }` and parses back to an invalid `Date` (`instanceof Date`, NaN time)
- valid Date: unchanged
- `null`: stays `null`
- nested invalid Dates inside objects/arrays: preserved

`npm test` stays green. The added "works for invalid dates" case fails on `main` and passes with this change.

### Scope

Only the invalid-Date path changes. Output produced by older versions (where an invalid Date became `null` with no annotation) still deserializes to `null`, so there is no change for previously serialized data.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent type-erasure bug where invalid `Date` objects (e.g. `new Date(NaN)`) were serialized to `null` and lost their `Date` annotation on round-trip. The fix widens the `isApplicable` guard from the strict `isDate` helper to `v instanceof Date` and serializes invalid dates as an empty string `""`, which `new Date("")` faithfully revives to an invalid Date.

- **`src/transformer.ts`**: replaces the `isDate` import with an inline `v instanceof Date` predicate and adds a ternary in the serializer that emits `""` for invalid dates instead of calling `.toISOString()`.
- **`src/index.test.ts`**: adds a `"works for invalid dates"` case that verifies the serialized form (`{ date: "" }`), the Date annotation, and that the parsed value is `instanceof Date` with a NaN time.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only changed path is the invalid-Date serialization, and valid dates, nulls, and all other types are completely unaffected.

The fix is narrowly scoped: it adds one ternary in the Date serializer and widens the isApplicable guard from valid-only to any Date instance. Valid dates continue to emit their ISO string exactly as before. The empty-string sentinel for invalid dates is a well-established pattern (used by devalue), new Date('') is universally an Invalid Date, and backward compatibility with previously serialized data is preserved. Tests cover the new case, the existing valid-date case is unchanged, and no other logic in the file is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/transformer.ts | Replaces `isDate` guard with `v instanceof Date` and serializes invalid dates to `""` instead of falling through to JSON null; logic is correct and backward-compatible. |
| src/index.test.ts | Adds a `"works for invalid dates"` test case with correct assertions for the serialized form, the Date annotation, and the revived invalid Date. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Value to serialize"] --> B{"v instanceof Date?"}
    B -- No --> C["Check other rules / fall through to JSON"]
    B -- Yes --> D{"isNaN(v.valueOf())?"}
    D -- Yes (invalid Date) --> E["Serialize to ''\n+ 'Date' annotation"]
    D -- No (valid Date) --> F["Serialize to v.toISOString()\n+ 'Date' annotation"]
    E --> G["JSON: { json: '', meta: { values: ['Date'] } }"]
    F --> H["JSON: { json: '2024-01-01T...', meta: { values: ['Date'] } }"]
    G --> I["Deserialize: new Date('')"]
    H --> J["Deserialize: new Date(isoString)"]
    I --> K["Invalid Date (NaN time)"]
    J --> L["Valid Date"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Value to serialize"] --> B{"v instanceof Date?"}
    B -- No --> C["Check other rules / fall through to JSON"]
    B -- Yes --> D{"isNaN(v.valueOf())?"}
    D -- Yes (invalid Date) --> E["Serialize to ''\n+ 'Date' annotation"]
    D -- No (valid Date) --> F["Serialize to v.toISOString()\n+ 'Date' annotation"]
    E --> G["JSON: { json: '', meta: { values: ['Date'] } }"]
    F --> H["JSON: { json: '2024-01-01T...', meta: { values: ['Date'] } }"]
    G --> I["Deserialize: new Date('')"]
    H --> J["Deserialize: new Date(isoString)"]
    I --> K["Invalid Date (NaN time)"]
    J --> L["Valid Date"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: preserve invalid Date instead of dr..."](https://github.com/flightcontrolhq/superjson/commit/d461802faa0690645fcc3fc2f0f9e286672e2832) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40526926)</sub>

<!-- /greptile_comment -->